### PR TITLE
Fix lowercase i in Instructor role

### DIFF
--- a/client/src/redux/userReducer/userAction.js
+++ b/client/src/redux/userReducer/userAction.js
@@ -41,7 +41,7 @@ export const getPm = () => (dispatch) => {
 }
 
 export const getInstructors = () => (dispatch) => {
-    return axios.get('/users/listAll?role=instructor')
+    return axios.get('/users/listAll?role=Instructor')
     .then(res => dispatch({type: GET_INSTRUCTORS, payload: res.data }))
     .catch(err => consoleLog(err));
     };


### PR DESCRIPTION
In userActions, the getInstructors action called the backend url with the lowercase "i", when it should be uppercase